### PR TITLE
Fixing bug on > method when index is zero

### DIFF
--- a/lib/juncture.rb
+++ b/lib/juncture.rb
@@ -43,19 +43,19 @@ class Juncture
   end
 
   def <(value)
-    @states[index+1..-1].include? value
+    index < @states.index(value)
   end
 
   def <=(value)
-    @states[index..-1].include? value
+    index <= @states.index(value)
   end
 
   def >(value)
-    @states[0..index-1].include? value
+    index > @states.index(value)
   end
 
   def >=(value)
-    @states[0..index].include? value
+    index >= @states.index(value)
   end
 
   private

--- a/lib/juncture/version.rb
+++ b/lib/juncture/version.rb
@@ -1,4 +1,4 @@
 class Juncture
-  VERSION = "0.1.4".freeze
-  DATE = "2014-02-10".freeze
+  VERSION = "0.2.0".freeze
+  DATE = "2016-12-20".freeze
 end

--- a/spec/juncture_spec.rb
+++ b/spec/juncture_spec.rb
@@ -79,72 +79,72 @@ describe Juncture do
   describe '#==' do
     it 'returns true if matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp == 2).to be_true
+      expect(temp == 2).to be true
     end
 
     it 'returns false if not matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp == 1).to be_false
+      expect(temp == 1).to be false
     end
   end
 
   describe '#===' do
     it 'returns true if matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp === 2).to be_true
+      expect(temp === 2).to be true
     end
 
     it 'returns false if not matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp === 1).to be_false
+      expect(temp === 1).to be false
     end
   end
 
   describe '#<' do
     it 'returns true if matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp < 3).to be_true
+      expect(temp < 3).to be true
     end
 
     it 'returns false if not matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp < 2).to be_false
+      expect(temp < 2).to be false
     end
   end
 
   describe '#<=' do
     it 'returns true if matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp <= 2).to be_true
+      expect(temp <= 2).to be true
     end
 
     it 'returns false if not matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp <= 1).to be_false
+      expect(temp <= 1).to be false
     end
   end
 
   describe '#>' do
     it 'returns true if matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp > 1).to be_true
+      expect(temp > 1).to be true
     end
 
     it 'returns false if not matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp > 2).to be_false
+      expect(temp > 2).to be false
     end
   end
 
   describe '#>=' do
     it 'returns true if matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp >= 2).to be_true
+      expect(temp >= 2).to be true
     end
 
     it 'returns false if not matching' do
       temp = Juncture.new 1, 2, 3, default: 2
-      expect(temp >= 3).to be_false
+      expect(temp >= 3).to be false
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ Coveralls.wear!
 require 'juncture'
 
 RSpec.configure do |config|
-  config.color_enabled = true
+  config.color         = true
   config.formatter     = :documentation
 end
 


### PR DESCRIPTION
This PR is to fix on the `>` method where it was returning `true` when evaluating the state with index 0 on the `states` variable.